### PR TITLE
fix: handle paginated response in listServers method

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -33,6 +33,26 @@ export interface BarndoorSDKOptions {
 }
 
 /**
+ * Pagination metadata for API responses.
+ */
+interface PaginationMetadata {
+  page: number;
+  limit: number;
+  total: number;
+  pages: number;
+  previous_page: number | null;
+  next_page: number | null;
+}
+
+/**
+ * Paginated API response structure.
+ */
+interface PaginatedResponse<T> {
+  data: T[];
+  pagination: PaginationMetadata;
+}
+
+/**
  * Options for ensureServerConnected method.
  */
 export interface EnsureServerConnectedOptions {
@@ -262,8 +282,8 @@ export class BarndoorSDK {
   public async listServers(): Promise<ServerSummary[]> {
     this._logger.debug('Fetching server list');
     try {
-      const response = await this._req('GET', '/servers') as unknown[];
-      const servers = response.map(data => ServerSummary.fromApiResponse(data));
+      const response = await this._req('GET', '/servers') as PaginatedResponse<unknown>;
+      const servers = response.data.map(data => ServerSummary.fromApiResponse(data));
       this._logger.info(`Retrieved ${servers.length} servers`);
       return servers;
     } catch (error) {

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -136,9 +136,21 @@ describe('BarndoorSDK Methods', () => {
         }
       ];
 
+      const mockPaginatedResponse = {
+        data: mockServers,
+        pagination: {
+          page: 1,
+          limit: 10,
+          total: 2,
+          pages: 1,
+          previous_page: null,
+          next_page: null
+        }
+      };
+
       mockFetch.mockResolvedValueOnce({
         ok: true,
-        json: () => Promise.resolve(mockServers)
+        json: () => Promise.resolve(mockPaginatedResponse)
       });
 
       const servers = await sdk.listServers();
@@ -160,9 +172,21 @@ describe('BarndoorSDK Methods', () => {
     });
 
     test('handles empty server list', async () => {
+      const mockEmptyResponse = {
+        data: [],
+        pagination: {
+          page: 1,
+          limit: 10,
+          total: 0,
+          pages: 0,
+          previous_page: null,
+          next_page: null
+        }
+      };
+
       mockFetch.mockResolvedValueOnce({
         ok: true,
-        json: () => Promise.resolve([])
+        json: () => Promise.resolve(mockEmptyResponse)
       });
 
       const servers = await sdk.listServers();


### PR DESCRIPTION
Resolves issue where SDK expected plain array but API returns paginated response.