### PR TITLE
feat(auth): first-class OAuth client-credentials (M2M) support

### DIFF
--- a/examples/m2m-client.js
+++ b/examples/m2m-client.js
@@ -1,0 +1,63 @@
+/**
+ * Minimal machine-to-machine example using OAuth client credentials.
+ *
+ * Demonstrates the headless flow: fetch a JWT via OAuth client
+ * credentials, list MCP servers, and tear down cleanly. Suitable for
+ * backend services, scheduled jobs, or CI pipelines where no user is
+ * present to complete the interactive PKCE flow.
+ *
+ * Environment variables:
+ *
+ *   BARNDOOR_API_BASE_URL      Platform API host for the caller's organization,
+ *                              NOT the auth/control-plane host. For trial
+ *                              tenants this is
+ *                              https://{org_slug}.platform.barndoor.ai; for
+ *                              enterprise tenants it is
+ *                              https://{org_slug}.mcp.barndoor.ai. The
+ *                              org_slug is encoded in the issued JWT's
+ *                              `organization_name` claim.
+ *   BARNDOOR_AUTH_ISSUER       OIDC issuer URL,
+ *                              e.g. https://auth.barndoor.ai/realms/barndoor
+ *   BARNDOOR_M2M_CLIENT_ID     OAuth client ID of a confidential Keycloak/Auth0
+ *                              client with "Service Accounts" enabled.
+ *   BARNDOOR_M2M_CLIENT_SECRET OAuth client secret for that client.
+ *   BARNDOOR_API_AUDIENCE      Defaults to "https://barndoor.ai/".
+ */
+
+import { BarndoorSDK } from '@barndoor-ai/sdk';
+
+async function main() {
+  const baseUrl = process.env.BARNDOOR_API_BASE_URL;
+  const issuer = process.env.BARNDOOR_AUTH_ISSUER;
+  const clientId = process.env.BARNDOOR_M2M_CLIENT_ID;
+  const clientSecret = process.env.BARNDOOR_M2M_CLIENT_SECRET;
+  const audience = process.env.BARNDOOR_API_AUDIENCE ?? 'https://barndoor.ai/';
+
+  if (!baseUrl || !issuer || !clientId || !clientSecret) {
+    throw new Error(
+      'Missing required env vars: BARNDOOR_API_BASE_URL, BARNDOOR_AUTH_ISSUER, ' +
+        'BARNDOOR_M2M_CLIENT_ID, BARNDOOR_M2M_CLIENT_SECRET'
+    );
+  }
+
+  const sdk = await BarndoorSDK.fromClientCredentials(baseUrl, {
+    clientId,
+    clientSecret,
+    audience,
+    issuer,
+  });
+
+  try {
+    const servers = await sdk.listServers();
+    for (const s of servers) {
+      console.log(`${s.slug.padEnd(30)} ${s.connection_status}`);
+    }
+  } finally {
+    await sdk.close();
+  }
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/auth/clientCredentials.ts
+++ b/src/auth/clientCredentials.ts
@@ -1,0 +1,166 @@
+/**
+ * OAuth 2.0 client-credentials (machine-to-machine) grant support.
+ *
+ * Mirrors the Python SDK's `get_client_credentials_token` /
+ * `get_client_credentials_token_async` helpers (PR #78).
+ */
+
+import { OAuthError } from '../exceptions';
+import { getOidcConfig } from './store';
+import { createScopedLogger } from '../logging';
+
+const _logger = createScopedLogger('client-credentials');
+
+/**
+ * Parameters for the client-credentials grant.
+ */
+export interface ClientCredentialsParams {
+  /** OAuth client ID for a Barndoor M2M application. */
+  clientId: string;
+  /** OAuth client secret. */
+  clientSecret: string;
+  /** API audience identifier (e.g., `https://barndoor.ai/`). */
+  audience: string;
+  /**
+   * OIDC issuer URL. Preferred over `domain`; OIDC discovery is used to
+   * locate the token endpoint.
+   */
+  issuer?: string;
+  /**
+   * Legacy auth domain (POSTs directly to `https://{domain}/oauth/token`).
+   * Provide either `issuer` or `domain`.
+   */
+  domain?: string;
+  /** Request timeout in milliseconds (default: 15000). */
+  timeoutMs?: number;
+}
+
+/**
+ * Resolve the token endpoint and form body for a client-credentials grant.
+ * @internal
+ */
+export async function _resolveClientCredentialsRequest(
+  params: ClientCredentialsParams
+): Promise<{ tokenEndpoint: string; body: URLSearchParams }> {
+  const { clientId, clientSecret, audience, issuer, domain } = params;
+
+  let tokenEndpoint: string;
+  if (issuer) {
+    const oidcConfig = await getOidcConfig(issuer);
+    tokenEndpoint = oidcConfig.token_endpoint;
+  } else if (domain) {
+    tokenEndpoint = `https://${domain}/oauth/token`;
+  } else {
+    throw new OAuthError("Either 'issuer' or 'domain' must be provided");
+  }
+
+  const body = new URLSearchParams({
+    grant_type: 'client_credentials',
+    client_id: clientId,
+    client_secret: clientSecret,
+    audience,
+  });
+
+  return { tokenEndpoint, body };
+}
+
+/**
+ * Perform the OAuth 2.0 client-credentials grant against the auth server
+ * and return the issued access token.
+ *
+ * Suitable for headless / machine-to-machine use cases where no interactive
+ * user is available. The token is returned directly without caching; for
+ * a ready-to-use SDK instance with automatic refresh, prefer
+ * {@link BarndoorSDK.fromClientCredentials}.
+ *
+ * @example
+ * ```ts
+ * const token = await getClientCredentialsToken({
+ *   clientId: process.env.BARNDOOR_M2M_CLIENT_ID!,
+ *   clientSecret: process.env.BARNDOOR_M2M_CLIENT_SECRET!,
+ *   audience: 'https://barndoor.ai/',
+ *   issuer: 'https://auth.barndoor.ai/realms/barndoor',
+ * });
+ * ```
+ */
+export async function getClientCredentialsToken(params: ClientCredentialsParams): Promise<string> {
+  const { timeoutMs = 15000 } = params;
+  const { tokenEndpoint, body } = await _resolveClientCredentialsRequest(params);
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetch(tokenEndpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: body.toString(),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      const errorData = (await response.json().catch(() => ({}))) as {
+        error?: string;
+        error_description?: string;
+      };
+      _logger.error('Client-credentials token endpoint error:', errorData);
+      throw new OAuthError(
+        `Client-credentials grant failed: ${
+          errorData.error_description ?? errorData.error ?? response.statusText
+        }`
+      );
+    }
+
+    const tokenData = (await response.json()) as { access_token?: string };
+    if (!tokenData.access_token) {
+      throw new OAuthError('Client-credentials grant: response missing access_token');
+    }
+    return tokenData.access_token;
+  } catch (error: unknown) {
+    if (error instanceof OAuthError) {
+      throw error;
+    }
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw new OAuthError(`Client-credentials grant timed out after ${timeoutMs}ms`);
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    throw new OAuthError(`Client-credentials grant failed: ${message}`);
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+/**
+ * Return true if the given JWT's `exp` claim is within `skewSeconds` of now.
+ *
+ * Tokens that cannot be parsed or have no `exp` claim are treated as
+ * already expired so callers err on the side of refreshing.
+ *
+ * @internal
+ */
+export function _tokenNearExpiry(token: string, skewSeconds: number): boolean {
+  const parts = token.split('.');
+  if (parts.length !== 3) {
+    return true;
+  }
+  const payloadPart = parts[1];
+  if (!payloadPart) {
+    return true;
+  }
+  let payload: { exp?: unknown };
+  try {
+    const base64 = payloadPart.replace(/-/g, '+').replace(/_/g, '/');
+    const decoded =
+      typeof Buffer !== 'undefined'
+        ? Buffer.from(base64, 'base64').toString('utf8')
+        : globalThis.atob(base64);
+    payload = JSON.parse(decoded) as { exp?: unknown };
+  } catch {
+    return true;
+  }
+  const exp = payload.exp;
+  if (typeof exp !== 'number') {
+    return true;
+  }
+  return exp - Date.now() / 1000 <= skewSeconds;
+}

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -7,6 +7,9 @@
 
 export { PKCEManager, startLocalCallbackServer } from './pkce';
 
+export { getClientCredentialsToken, _tokenNearExpiry } from './clientCredentials';
+export type { ClientCredentialsParams } from './clientCredentials';
+
 export {
   getTokenStorage,
   TokenManager,

--- a/src/auth/store.ts
+++ b/src/auth/store.ts
@@ -35,7 +35,7 @@ const _oidcConfigCache = new Map<string, OidcConfig>();
  * Fetch and cache OIDC configuration from the issuer's discovery endpoint.
  *
  * @param issuer - The OIDC issuer URL (e.g., https://auth.barndoor.ai or
- *                 https://auth.barndoordev.com/realms/barndoor)
+ *                 https://auth.barndoor.ai/realms/barndoor)
  * @returns OIDC configuration containing endpoints like token_endpoint, jwks_uri, etc.
  */
 export async function getOidcConfig(issuer: string): Promise<OidcConfig> {

--- a/src/client.ts
+++ b/src/client.ts
@@ -10,9 +10,17 @@ import { ServerSummary, ServerDetail } from './models';
 import { HTTPError, ConfigurationError, TokenError, ServerNotFoundError } from './exceptions';
 import { getStaticConfig, isNode } from './config';
 import { getOidcConfig } from './auth';
+import {
+  ClientCredentialsParams,
+  getClientCredentialsToken,
+  _tokenNearExpiry,
+} from './auth/clientCredentials';
 import { createScopedLogger } from './logging';
 import { spawn } from 'child_process';
 import os from 'os';
+
+/** Refresh M2M tokens this many seconds before their `exp` claim. */
+const M2M_REFRESH_SKEW_SECONDS = 60;
 
 /**
  * Configuration options for BarndoorSDK constructor.
@@ -74,6 +82,16 @@ export interface ConnectionStatusResponse {
 }
 
 /**
+ * Options for {@link BarndoorSDK.fromClientCredentials}.
+ */
+export interface FromClientCredentialsOptions extends ClientCredentialsParams {
+  /** Request timeout in seconds for API calls (default: 30). */
+  timeout?: number;
+  /** Maximum number of retries for API calls (default: 3). */
+  maxRetries?: number;
+}
+
+/**
  * Async client for interacting with the Barndoor Platform API.
  *
  * This SDK provides methods to:
@@ -95,6 +113,8 @@ export class BarndoorSDK {
   private _tokenValidated: boolean;
   /** Whether the SDK has been closed */
   private _closed: boolean;
+  /** Cached client-credentials parameters for automatic token refresh. */
+  private _credentials: ClientCredentialsParams | null = null;
   /** Scoped logger for this SDK instance */
   private readonly _logger = createScopedLogger('client');
 
@@ -128,6 +148,49 @@ export class BarndoorSDK {
     this._closed = false;
 
     this._logger.info(`Initialized BarndoorSDK for ${this.base}`);
+  }
+
+  /**
+   * Build a {@link BarndoorSDK} authenticated via the OAuth 2.0
+   * client-credentials (machine-to-machine) grant.
+   *
+   * Performs the grant against the Barndoor auth server and returns a
+   * ready-to-use SDK instance. The credentials are retained on the
+   * instance so the access token can be refreshed automatically when it
+   * nears expiry or when the API responds with 401.
+   *
+   * @example
+   * ```ts
+   * const sdk = await BarndoorSDK.fromClientCredentials(
+   *   'https://api.barndoor.host',
+   *   {
+   *     clientId: process.env.BARNDOOR_M2M_CLIENT_ID!,
+   *     clientSecret: process.env.BARNDOOR_M2M_CLIENT_SECRET!,
+   *     audience: 'https://barndoor.ai/',
+   *     issuer: 'https://auth.barndoor.ai/realms/barndoor',
+   *   }
+   * );
+   * const servers = await sdk.listServers();
+   * ```
+   */
+  public static async fromClientCredentials(
+    apiBaseUrl: string,
+    options: FromClientCredentialsOptions
+  ): Promise<BarndoorSDK> {
+    const { timeout, maxRetries, ...credentials } = options;
+
+    const token = await getClientCredentialsToken(credentials);
+
+    const sdkOptions: BarndoorSDKOptions = { token };
+    if (timeout !== undefined) sdkOptions.timeout = timeout;
+    if (maxRetries !== undefined) sdkOptions.maxRetries = maxRetries;
+
+    const sdk = new BarndoorSDK(apiBaseUrl, sdkOptions);
+    sdk._credentials = { ...credentials };
+    // M2M tokens come from the auth server we just called — no need to
+    // re-validate via the API on every request.
+    sdk._tokenValidated = true;
+    return sdk;
   }
 
   /**
@@ -212,12 +275,57 @@ export class BarndoorSDK {
   ): Promise<unknown> {
     this._ensureNotClosed();
     await this.ensureValidToken();
-
-    const headers = (options['headers'] as Record<string, string>) ?? {};
-    headers['Authorization'] = `Bearer ${this.token}`;
+    await this._maybeRefreshM2MToken();
 
     const url = `${this.base}${path}`;
-    return await this._http.request(method, url, { ...options, headers });
+    const buildOptions = (): Record<string, unknown> => {
+      const headers = { ...((options['headers'] as Record<string, string>) ?? {}) };
+      headers['Authorization'] = `Bearer ${this.token}`;
+      return { ...options, headers };
+    };
+
+    try {
+      return await this._http.request(method, url, buildOptions());
+    } catch (error: unknown) {
+      // For M2M sessions, transparently refresh once on 401 and retry.
+      if (error instanceof HTTPError && error.statusCode === 401 && this._credentials !== null) {
+        this._logger.info('M2M token rejected (401); refreshing and retrying once');
+        await this._refreshM2MToken();
+        return await this._http.request(method, url, buildOptions());
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Refresh the M2M access token if it is near expiry.
+   *
+   * No-op for SDK instances not created via {@link BarndoorSDK.fromClientCredentials}.
+   * @private
+   */
+  private async _maybeRefreshM2MToken(): Promise<void> {
+    if (this._credentials === null) {
+      return;
+    }
+    if (!_tokenNearExpiry(this.token, M2M_REFRESH_SKEW_SECONDS)) {
+      return;
+    }
+    this._logger.debug('M2M token near expiry; refreshing');
+    await this._refreshM2MToken();
+  }
+
+  /**
+   * Unconditionally fetch a fresh M2M token using stored credentials.
+   * @private
+   */
+  private async _refreshM2MToken(): Promise<void> {
+    if (this._credentials === null) {
+      throw new Error(
+        '_refreshM2MToken() called on an SDK not created via BarndoorSDK.fromClientCredentials()'
+      );
+    }
+    this._token = await getClientCredentialsToken(this._credentials);
+    this._tokenValidated = true;
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@
 
 // Main SDK class
 export { BarndoorSDK } from './client';
+export type { FromClientCredentialsOptions } from './client';
 
 // Exception classes
 export {
@@ -73,8 +74,9 @@ export {
   TokenManager,
   getOidcConfig,
   clearOidcConfigCache,
+  getClientCredentialsToken,
 } from './auth';
-export type { OidcConfig } from './auth';
+export type { OidcConfig, ClientCredentialsParams } from './auth';
 
 // Configuration
 export {

--- a/test/client-credentials.test.js
+++ b/test/client-credentials.test.js
@@ -1,0 +1,316 @@
+/**
+ * Tests for OAuth client-credentials (M2M) support.
+ */
+
+import * as SDK from '../dist/index.esm.js';
+const { BarndoorSDK, getClientCredentialsToken, OAuthError, HTTPError } = SDK;
+
+// JWT helper — produces an unsigned-looking JWT with the given exp offset.
+function makeJwt(expSecondsFromNow) {
+  const header = Buffer.from(JSON.stringify({ alg: 'none', typ: 'JWT' }))
+    .toString('base64')
+    .replace(/=+$/, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_');
+  const payload = Buffer.from(
+    JSON.stringify({ exp: Math.floor(Date.now() / 1000) + expSecondsFromNow })
+  )
+    .toString('base64')
+    .replace(/=+$/, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_');
+  return `${header}.${payload}.sig`;
+}
+
+// Mock fetch with queue support.
+const mockFetch = {
+  responseQueue: [],
+  calls: [],
+  mockResolvedValueOnce(value) {
+    this.responseQueue.push({ type: 'resolve', value });
+    return this;
+  },
+  mockRejectedValueOnce(error) {
+    this.responseQueue.push({ type: 'reject', value: error });
+    return this;
+  },
+  mockClear() {
+    this.responseQueue = [];
+    this.calls = [];
+  },
+};
+
+const realFetch = global.fetch;
+
+beforeEach(() => {
+  mockFetch.mockClear();
+  global.fetch = (...args) => {
+    mockFetch.calls.push(args);
+    if (mockFetch.responseQueue.length > 0) {
+      const r = mockFetch.responseQueue.shift();
+      return r.type === 'resolve' ? Promise.resolve(r.value) : Promise.reject(r.value);
+    }
+    return Promise.reject(new Error('No mock response queued'));
+  };
+  process.env.BARNDOOR_ENV = 'test';
+});
+
+afterEach(() => {
+  global.fetch = realFetch;
+  delete process.env.BARNDOOR_ENV;
+});
+
+// Helpers to mock the OIDC discovery + token endpoint pair.
+function queueOidcDiscovery(issuer, tokenEndpoint) {
+  mockFetch.mockResolvedValueOnce({
+    ok: true,
+    headers: { get: () => 'application/json' },
+    json: () =>
+      Promise.resolve({
+        issuer,
+        token_endpoint: tokenEndpoint,
+        authorization_endpoint: `${issuer}/authorize`,
+        userinfo_endpoint: `${issuer}/userinfo`,
+        jwks_uri: `${issuer}/jwks`,
+      }),
+    text: () => Promise.resolve(''),
+  });
+}
+
+function queueTokenResponse(token, ok = true, body = {}) {
+  mockFetch.mockResolvedValueOnce({
+    ok,
+    status: ok ? 200 : 400,
+    statusText: ok ? 'OK' : 'Bad Request',
+    headers: { get: () => 'application/json' },
+    json: () => Promise.resolve(ok ? { access_token: token } : body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+  });
+}
+
+describe('getClientCredentialsToken', () => {
+  test('posts grant against discovered token endpoint and returns access_token', async () => {
+    SDK.clearOidcConfigCache();
+    queueOidcDiscovery('https://issuer.test', 'https://issuer.test/token');
+    queueTokenResponse('abc.def.ghi');
+
+    const token = await getClientCredentialsToken({
+      clientId: 'cid',
+      clientSecret: 'csec',
+      audience: 'https://barndoor.ai/',
+      issuer: 'https://issuer.test',
+    });
+
+    expect(token).toBe('abc.def.ghi');
+
+    // Second call is the token grant.
+    const [url, init] = mockFetch.calls[1];
+    expect(url).toBe('https://issuer.test/token');
+    expect(init.method).toBe('POST');
+    expect(init.headers['Content-Type']).toBe('application/x-www-form-urlencoded');
+    const params = new URLSearchParams(init.body);
+    expect(params.get('grant_type')).toBe('client_credentials');
+    expect(params.get('client_id')).toBe('cid');
+    expect(params.get('client_secret')).toBe('csec');
+    expect(params.get('audience')).toBe('https://barndoor.ai/');
+  });
+
+  test('falls back to https://{domain}/oauth/token when no issuer is given', async () => {
+    queueTokenResponse('tok');
+
+    const token = await getClientCredentialsToken({
+      clientId: 'cid',
+      clientSecret: 'csec',
+      audience: 'https://barndoor.ai/',
+      domain: 'auth.example.com',
+    });
+
+    expect(token).toBe('tok');
+    expect(mockFetch.calls[0][0]).toBe('https://auth.example.com/oauth/token');
+  });
+
+  test('throws OAuthError when neither issuer nor domain is given', async () => {
+    await expect(
+      getClientCredentialsToken({
+        clientId: 'cid',
+        clientSecret: 'csec',
+        audience: 'https://barndoor.ai/',
+      })
+    ).rejects.toThrow(OAuthError);
+  });
+
+  test('throws OAuthError on non-2xx token response', async () => {
+    queueTokenResponse('', false, { error: 'invalid_client' });
+
+    await expect(
+      getClientCredentialsToken({
+        clientId: 'cid',
+        clientSecret: 'wrong',
+        audience: 'https://barndoor.ai/',
+        domain: 'auth.example.com',
+      })
+    ).rejects.toThrow(/invalid_client/);
+  });
+});
+
+describe('BarndoorSDK.fromClientCredentials', () => {
+  test('fetches a token and produces a working SDK instance', async () => {
+    SDK.clearOidcConfigCache();
+    queueOidcDiscovery('https://issuer.test', 'https://issuer.test/token');
+    queueTokenResponse(makeJwt(3600));
+
+    const sdk = await BarndoorSDK.fromClientCredentials('https://api.example.com', {
+      clientId: 'cid',
+      clientSecret: 'csec',
+      audience: 'https://barndoor.ai/',
+      issuer: 'https://issuer.test',
+    });
+
+    try {
+      expect(sdk.token).toMatch(/\./);
+      expect(sdk.base).toBe('https://api.example.com');
+    } finally {
+      await sdk.close();
+    }
+  });
+
+  test('refreshes near-expiry token before next request', async () => {
+    SDK.clearOidcConfigCache();
+    const stale = makeJwt(10); // within 60s skew
+    const fresh = makeJwt(3600);
+
+    queueOidcDiscovery('https://issuer.test', 'https://issuer.test/token');
+    queueTokenResponse(stale);
+
+    const sdk = await BarndoorSDK.fromClientCredentials('https://api.example.com', {
+      clientId: 'cid',
+      clientSecret: 'csec',
+      audience: 'https://barndoor.ai/',
+      issuer: 'https://issuer.test',
+    });
+
+    try {
+      // Refresh issues another token grant; OIDC config is cached so no
+      // second discovery call.
+      queueTokenResponse(fresh);
+      // Then the API request itself.
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: { get: () => 'application/json' },
+        json: () =>
+          Promise.resolve({
+            data: [],
+            pagination: {
+              page: 1,
+              limit: 10,
+              total: 0,
+              pages: 1,
+              previous_page: null,
+              next_page: null,
+            },
+          }),
+        text: () => Promise.resolve(''),
+      });
+
+      const servers = await sdk.listServers();
+      expect(servers).toHaveLength(0);
+      expect(sdk.token).toBe(fresh);
+
+      // The API call must carry the refreshed bearer.
+      const apiCall = mockFetch.calls.find(
+        ([url]) => url === 'https://api.example.com/api/servers'
+      );
+      expect(apiCall).toBeDefined();
+      expect(apiCall[1].headers.Authorization).toBe(`Bearer ${fresh}`);
+    } finally {
+      await sdk.close();
+    }
+  });
+
+  test('retries exactly once on 401 with a refreshed token', async () => {
+    SDK.clearOidcConfigCache();
+    const first = makeJwt(3600);
+    const second = makeJwt(3600);
+
+    queueOidcDiscovery('https://issuer.test', 'https://issuer.test/token');
+    queueTokenResponse(first);
+
+    const sdk = await BarndoorSDK.fromClientCredentials('https://api.example.com', {
+      clientId: 'cid',
+      clientSecret: 'csec',
+      audience: 'https://barndoor.ai/',
+      issuer: 'https://issuer.test',
+    });
+
+    try {
+      // First API call → 401.
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        statusText: 'Unauthorized',
+        headers: { get: () => 'application/json' },
+        text: () => Promise.resolve(''),
+        json: () => Promise.resolve({}),
+      });
+      // Refresh.
+      queueTokenResponse(second);
+      // Second (retried) API call succeeds.
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: { get: () => 'application/json' },
+        json: () =>
+          Promise.resolve({
+            data: [],
+            pagination: {
+              page: 1,
+              limit: 10,
+              total: 0,
+              pages: 1,
+              previous_page: null,
+              next_page: null,
+            },
+          }),
+        text: () => Promise.resolve(''),
+      });
+
+      const servers = await sdk.listServers();
+      expect(servers).toHaveLength(0);
+      expect(sdk.token).toBe(second);
+
+      const apiCalls = mockFetch.calls.filter(
+        ([url]) => url === 'https://api.example.com/api/servers'
+      );
+      expect(apiCalls).toHaveLength(2);
+      expect(apiCalls[0][1].headers.Authorization).toBe(`Bearer ${first}`);
+      expect(apiCalls[1][1].headers.Authorization).toBe(`Bearer ${second}`);
+    } finally {
+      await sdk.close();
+    }
+  });
+
+  test('plain SDK without M2M credentials propagates 401 unchanged', async () => {
+    const sdk = new BarndoorSDK('https://api.example.com', { token: makeJwt(3600) });
+
+    try {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        statusText: 'Unauthorized',
+        headers: { get: () => 'application/json' },
+        text: () => Promise.resolve(''),
+        json: () => Promise.resolve({}),
+      });
+
+      await expect(sdk.listServers()).rejects.toThrow(HTTPError);
+
+      const apiCalls = mockFetch.calls.filter(
+        ([url]) => url === 'https://api.example.com/api/servers'
+      );
+      expect(apiCalls).toHaveLength(1);
+    } finally {
+      await sdk.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Promote OAuth 2.0 client-credentials (M2M) to a first-class flow alongside
the existing interactive PKCE login, mirroring [barndoor-python-sdk#78][py].
Enables non-interactive use cases — backend services, scheduled jobs, CI
pipelines — without forcing callers to fetch tokens by hand and reinvent
refresh / 401 handling.

[py]: https://github.com/barndoor-ai/barndoor-python-sdk/pull/78

## Changes

`src/auth/clientCredentials.ts` (new)

- `getClientCredentialsToken({ clientId, clientSecret, audience, issuer?, domain?, timeoutMs? })`
  performs the grant. Prefers OIDC discovery via `issuer`; falls back to
  `https://{domain}/oauth/token`. Throws `OAuthError` if neither is given,
  on non-2xx responses, or on timeout.
- Internal `_tokenNearExpiry(token, skewSeconds)` — JWT `exp` parser that
  errs toward refreshing on parse failure or missing claim.

`src/client.ts`

- New `BarndoorSDK.fromClientCredentials(baseUrl, opts)` async static
  factory. Fetches the initial token, caches the credentials on the
  instance, and skips the userinfo re-validation hop (the auth server we
  just called is authoritative).
- `_req` now refreshes the M2M token automatically when it is within 60s
  of `exp`, and transparently retries once on a 401 response. M2M
  sessions only — plain SDK instances still propagate 401 unchanged.

`src/auth/index.ts`, `src/index.ts`

- Re-export `getClientCredentialsToken` and `ClientCredentialsParams`
  / `FromClientCredentialsOptions` types.

`src/auth/store.ts`

- Drop a stray non-prod hostname from a doc comment.

Tests (`test/client-credentials.test.js`, 8 new cases)

- Sync grant helper: correct token endpoint via OIDC discovery, correct
  form body, `domain` fallback, missing-issuer-and-domain error, non-2xx
  error mapping.
- `BarndoorSDK.fromClientCredentials` end-to-end: factory wires up
  credentials and produces a working SDK; near-expiry refresh kicks in
  before the next request and the refreshed bearer is sent; a 401
  triggers exactly one retry with the fresh bearer; plain SDK clients
  (no creds) still propagate 401 without retrying.

Example (`examples/m2m-client.js`)

- Minimal headless backend usage; lists MCP servers via the new factory.

## Verification

- `npm run build` — clean.
- `npm test` — 11 suites, 114 passed / 5 skipped (8 new + 111 existing).
- `npm run type-check` — clean.
- `npm run lint` — 0 errors / 0 warnings on the new/changed files.
- Manual end-to-end against a dev tenant: `BarndoorSDK.fromClientCredentials`
  successfully issued a JWT, hit `/api/servers`, returned 3 servers.
