### PR TITLE
Release v1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@barndoor-ai/sdk",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@barndoor-ai/sdk",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@bufbuild/protobuf": "^2.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barndoor-ai/sdk",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "TypeScript/JavaScript client for the Barndoor Platform API",
   "author": "Barndoor AI, Inc. (https://barndoor.ai)",
   "homepage": "https://barndoor.ai",


### PR DESCRIPTION
Bumps version to **1.2.0**. This release adds first-class M2M auth support and migrates publishing to OIDC.

## Highlights since v1.1.0

### Features

- **#74** — first-class OAuth client-credentials (M2M) flow. New `BarndoorSDK.fromClientCredentials(baseUrl, opts)` factory, plus `getClientCredentialsToken` helper. The factory caches credentials on the instance, refreshes the token automatically within 60s of `exp`, and transparently retries once on a 401. Enables non-interactive use from backend services, scheduled jobs, and CI pipelines without callers reinventing refresh/retry. Mirrors [barndoor-python-sdk#78](https://github.com/barndoor-ai/barndoor-python-sdk/pull/78).

### Internal / infra

- **#75** — CI publish job switched from `NPM_TOKEN` to npm trusted publishing (OIDC). Provenance retained. Post-release we'll delete the old `NPM_TOKEN` secret and revoke the matching access token. **This release is the first validation of the new auth path.**
- **#65** — regenerated proto stubs against `bdai-platform@c3d66945`.
- **#62** — added `@bufbuild/protobuf` and `@connectrpc/connect` (used by the regenerated stubs).
- **#60** — removed v1 refs from OpenAPI spec (v1 methods were never implemented in the SDK).

### Chores

- Dependency bumps (Dependabot): minimatch, express-rate-limit, ajv, @hono/node-server, hono, picomatch, flatted, serialize-javascript, @rollup/plugin-terser, path-to-regexp, rollup, qs.
- Octo policy added (#59), `platform-publish.sts.yaml` added/updated (#61, #64).

## Test plan

- [ ] CI green on this PR (build + lint + tests + type-check).
- [ ] Merge to `main`.
- [ ] Tag `v1.2.0` from `main` and push.
- [ ] Create GitHub release `v1.2.0` — this triggers the `publish` job and validates the new trusted-publishing auth path.
- [ ] Verify `@barndoor-ai/sdk@1.2.0` appears on https://www.npmjs.com/package/@barndoor-ai/sdk with provenance.
- [ ] Smoke-test install: `npm install @barndoor-ai/sdk@1.2.0` in a scratch dir.
- [ ] Post-release: delete `NPM_TOKEN` secret from repo settings (and `release` environment if scoped there); revoke the matching token on npmjs.com.

🤖 Generated with [Claude Code](https://claude.com/claude-code)