### PR TITLE
chore(ci): use node 24 in publish job for npm 11+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,10 +45,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           registry-url: 'https://registry.npmjs.org'
-
-      - run: npm install -g npm@latest
 
       - run: npm ci
 


### PR DESCRIPTION
## Summary

Hotfix for the `Publish` job, which failed on the v1.2.0 release run ([26248328961](https://github.com/barndoor-ai/barndoor-ts-sdk/actions/runs/26248328961)) at the `npm install -g npm@latest` step:

```
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'promise-retry'
```

This is a known flake when npm 10.x self-replaces with npm 11.x in-place — half-replaced internals reference a module that has already been removed.

## Fix

Bump the publish job to Node 24, which ships with npm 11+ natively. Trusted publishing requires npm ≥ 11.5.1; Node 24's bundled npm satisfies it without a self-upgrade step.

- Build/test job stays on Node 22 (matches `"engines": { "node": ">=22" }` in `package.json`, so we still verify the package builds against its declared minimum).
- Publish job has no such constraint — it just needs npm capable of trusted publishing.

## Re-publishing v1.2.0

The npm package is not on the registry; the publish failed before upload. Plan after this merges:

1. Delete and re-create the `v1.2.0` tag pointing at the new HEAD on `main`.
2. Delete the existing GitHub release (keeping the tag detached is not useful here).
3. Recreate the GitHub release, which re-fires `release: published` and re-runs the workflow against the fixed file.

## Test plan

- [ ] CI green on this PR (build + lint + tests).
- [ ] Merge to `main`.
- [ ] Re-tag and recreate the `v1.2.0` release per the steps above.
- [ ] Confirm `publish` job succeeds and `@barndoor-ai/sdk@1.2.0` appears on npm with provenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)