### PR TITLE
chore(ci): pin actions to Node 24 SHAs (BCP-2208)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: npm
@@ -42,8 +42,8 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
## What & why

Node.js 20 is deprecated for GitHub Actions ([BCP-2208](https://barndoor-team.atlassian.net/browse/BCP-2208)). This pins the JS actions in `ci.yml` to commit SHAs of their Node 24 releases (per Tim's "pin git sha" note on the ticket).

| Action | Before | After |
|---|---|---|
| `actions/checkout` | `@v4` (node20) | `de0fac2e` # v6.0.2 (node24) |
| `actions/setup-node` | `@v4` (node20) | `48b55a01` # v6.4.0 (node24) |

Versions match the pins already vetted in `bdai-platform`.

## Validation
- `actionlint` clean.
- Value-only changes to `uses:`; no behavioral change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)