### PR TITLE
fix(deps): patch hono CVEs via npm override (CVE-2026-39407/08/09/10, GHSA-26pp-8wgv-hjvm, GHSA-v8w9-8mx6-g223)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5478,9 +5478,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.5",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.5.tgz",
-      "integrity": "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==",
+      "version": "4.12.27",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
+      "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/package.json
+++ b/package.json
@@ -88,7 +88,8 @@
   },
   "overrides": {
     "@babel/plugin-transform-modules-systemjs": "^7.29.4",
-    "fast-uri": "^3.1.2"
+    "fast-uri": "^3.1.2",
+    "hono": "^4.12.27"
   },
   "typeCoverage": {
     "atLeast": 60,


### PR DESCRIPTION
## Summary

- Pins `hono` to `^4.12.27` via npm `overrides` (was `4.12.5` via `@modelcontextprotocol/sdk`)
- Addresses 6 CVEs/GHSAs affecting `hono` as a transitive dependency

## Vulnerabilities patched

| ID | Affected versions | Fixed in |
|----|-------------------|----------|
| CVE-2026-39408 | `>= 4.0.0, <= 4.12.11` | 4.12.12 |
| CVE-2026-39407 | `< 4.12.12` | 4.12.12 |
| CVE-2026-39409 | `< 4.12.12` | 4.12.12 |
| GHSA-26pp-8wgv-hjvm | `< 4.12.12` | 4.12.12 |
| CVE-2026-39410 | `< 4.12.12` | 4.12.12 |
| GHSA-v8w9-8mx6-g223 | `< 4.12.7` | 4.12.7 |

## Test plan

- [x] `npm ls hono` confirms `hono@4.12.27` resolves for all dependents
- [ ] CI passes (build + tests unchanged, no hono APIs are used directly in this SDK)

🤖 Generated with [Claude Code](https://claude.com/claude-code)